### PR TITLE
Add AppModuleBasic for ibc authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Override modules for `params` and `upgrades` Cosmos SDK v0.45.x modules, with an
 `params` has an additional message, `MsgUpdateParams`, which allows the authority to update params.
 
 `upgrade` has additional messages `MsgSoftwareUpgrade` and `MsgCancelUpgrade` which allow the authority to schedule and cancel scheduled upgrades.
+
+`ibc-authority` is a slim `AppModuleBasic` with messages `MsgClientUpdate` and `MsgUpgrade`, which allow the authority to substitute and upgrade light clients.

--- a/x/ibc/client/cli/tx.go
+++ b/x/ibc/client/cli/tx.go
@@ -16,6 +16,19 @@ import (
 	"github.com/strangelove-ventures/paramauthority/x/ibc/types"
 )
 
+// GetTxCmd returns the transaction commands for this module
+func GetTxCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   types.ModuleName,
+		Short: "IBC authority transaction subcommands",
+	}
+
+	cmd.AddCommand(NewCmdSubmitUpdateClientProposal())
+	cmd.AddCommand(NewCmdSubmitUpgradeProposal())
+
+	return cmd
+}
+
 // NewCmdSubmitUpdateClientProposal implements a command handler for submitting an update IBC client proposal transaction.
 func NewCmdSubmitUpdateClientProposal() *cobra.Command {
 	cmd := &cobra.Command{

--- a/x/ibc/module.go
+++ b/x/ibc/module.go
@@ -1,0 +1,64 @@
+package ibc
+
+import (
+	"encoding/json"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+
+	"github.com/gorilla/mux"
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/strangelove-ventures/paramauthority/x/ibc/client/cli"
+	"github.com/strangelove-ventures/paramauthority/x/ibc/types"
+	"github.com/strangelove-ventures/paramauthority/x/params/types/proposal"
+)
+
+var (
+	_ module.AppModuleBasic = AppModuleBasic{}
+)
+
+// AppModuleBasic defines the basic application module used by the params module.
+type AppModuleBasic struct{}
+
+// Name returns the params module's name.
+func (AppModuleBasic) Name() string {
+	return types.ModuleName
+}
+
+// RegisterLegacyAminoCodec registers the params module's types on the given LegacyAmino codec.
+func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+	types.RegisterLegacyAminoCodec(cdc)
+}
+
+// DefaultGenesis returns default genesis state as raw bytes for the params
+// module.
+func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+	return cdc.MustMarshalJSON(proposal.DefaultGenesis())
+}
+
+// ValidateGenesis performs genesis state validation for the params module.
+func (AppModuleBasic) ValidateGenesis(_ codec.JSONCodec, config client.TxEncodingConfig, _ json.RawMessage) error {
+	return nil
+}
+
+// RegisterRESTRoutes registers the REST routes for the params module.
+func (AppModuleBasic) RegisterRESTRoutes(_ client.Context, _ *mux.Router) {}
+
+// RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the params module.
+func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {}
+
+// GetTxCmd returns no root tx command for the params module.
+func (AppModuleBasic) GetTxCmd() *cobra.Command { return cli.GetTxCmd() }
+
+// GetQueryCmd returns no root query command for the params module.
+func (AppModuleBasic) GetQueryCmd() *cobra.Command {
+	return nil
+}
+
+func (am AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
+	types.RegisterInterfaces(registry)
+}

--- a/x/ibc/types/keys.go
+++ b/x/ibc/types/keys.go
@@ -1,0 +1,3 @@
+package types
+
+const ModuleName = "ibc-authority"


### PR DESCRIPTION
Within the chain, an AppModuleBasic is required for the codecs to be registered properly for the CLI commands.

Now the ibc authority commands are:

```
IBC authority transaction subcommands

Usage:
  chaind tx ibc-authority [command]

Available Commands:
  ibc-upgrade   Submit an IBC upgrade proposal
  update-client Submit an update IBC client proposal
```